### PR TITLE
Initial Key-exchange for lagged replicas on completing ST

### DIFF
--- a/bftengine/include/bftengine/IStateTransfer.hpp
+++ b/bftengine/include/bftengine/IStateTransfer.hpp
@@ -109,6 +109,9 @@ class IReplicaForStateTransfer {
   // Invoke State Transfer timer callback once
   virtual concordUtil::Timers::Handle addOneShotTimer(uint32_t timeoutMilli) = 0;
 
+  // Check for key-exchange after completing ST
+  virtual void checkForKeyExchange() = 0;
+
   virtual ~IReplicaForStateTransfer() = default;
 };
 }  // namespace bftEngine

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -2736,6 +2736,10 @@ void BCStateTran::processData(bool lastInBatch) {
 
       g.txn()->setIsFetchingState(false);
       ConcordAssertEQ(getFetchingState(), FetchingState::NotFetching);
+      // Note: Key exchange message is sent as internal bft client request and
+      // it will be dropped by message handler if curr_state == fetching
+      // So we need to invoke this cb after setting state to NotFetching
+      replicaForStateTransfer_->checkForKeyExchange();
       break;
     } else if (!badDataFromCurrentSourceReplica) {
       //////////////////////////////////////////////////////////////////////////

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
@@ -128,5 +128,8 @@ Timers::Handle ReplicaForStateTransfer::addOneShotTimer(uint32_t timeoutMilli) {
                      concordUtil::Timers::Timer::ONESHOT,
                      [this](concordUtil::Timers::Handle h) { stateTransfer->onTimer(); });
 }
+void ReplicaForStateTransfer::checkForKeyExchange() {
+  if (check_for_key_exchange_cb_) check_for_key_exchange_cb_();
+}
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
@@ -37,7 +37,7 @@ class ReplicaForStateTransfer : public IReplicaForStateTransfer, public ReplicaB
   void onTransferringComplete(uint64_t checkpointNumberOfNewState) override;
   void changeStateTransferTimerPeriod(uint32_t timerPeriodMilli) override;
   Timers::Handle addOneShotTimer(uint32_t timeoutMilli) override;
-
+  void checkForKeyExchange() override;
   bool isCollectingState() const { return stateTransfer->isCollectingState(); }
 
   void start() override;
@@ -66,6 +66,7 @@ class ReplicaForStateTransfer : public IReplicaForStateTransfer, public ReplicaB
   concordMetrics::GaugeHandle metric_state_transfer_timer_;
   bool firstTime_;
   std::shared_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> cre_;
+  std::function<void()> check_for_key_exchange_cb_;
 };
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -171,6 +171,7 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
     concordUtil::Timers::Handle addOneShotTimer(uint32_t timeoutMilli) override {
       return realInterface_->addOneShotTimer(timeoutMilli);
     }
+    void checkForKeyExchange() override {}
   };
 
   friend struct ReplicaWrapper;

--- a/bftengine/tests/bcstatetransfer/test_replica.hpp
+++ b/bftengine/tests/bcstatetransfer/test_replica.hpp
@@ -54,6 +54,8 @@ class TestReplica : public IReplicaForStateTransfer {
   void changeStateTransferTimerPeriod(uint32_t timerPeriodMilli) override{};
 
   concordUtil::Timers::Handle addOneShotTimer(uint32_t timeoutMilli) override { return concordUtil::Timers::Handle(); }
+
+  void checkForKeyExchange() override {}
   ///////////////////////////////////////////////////////////////////////////
   // Data - All public on purpose, so that it can be accessed by tests
   ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
With (n-f) initial key exchange support, we do initial key exchange for live replicas only. Lagged replicas get the public keys of peer replicas from reserved pages. But, we also need to generate key pair and perform key-exchange for lagged replicas as well. this PR addresses this issue.